### PR TITLE
Clarify README comment about limit and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ BlogPost
   .select('COUNT')
   .exec(callback);
 
-// only return title and content attributes of 10 blog posts
+// Read 10 blog posts and only return title and content attributes of posts
 // that begin with the title Expanding
 BlogPost
   .query('werner@example.com')


### PR DESCRIPTION
The current README comment could be interpreted to mean that the query continues looking until it finds 10 entries matching the filters.